### PR TITLE
Write git commit hash to stdout when compiled from clean repo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,19 @@ PROGRAM = spectre.out
 SOURCE  = spectre.c
      
 all: $(PROGRAM)
+
+GIT_SHELL_EXIT := $(shell git status --porcelain 2> /dev/null >&2 ; echo $$?)
+
+# It can be non-zero when not in git repository or git is not installed.
+# It can happen when downloaded using github's "Download ZIP" option.
+ifeq ($(GIT_SHELL_EXIT),0)
+# Check if working dir is clean.
+GIT_STATUS := $(shell git status --porcelain)
+ifndef GIT_STATUS
+GIT_COMMIT_HASH := $(shell git rev-parse HEAD)
+CFLAGS += -DGIT_COMMIT_HASH='"$(GIT_COMMIT_HASH)"'
+endif
+endif
      
 $(PROGRAM): $(SOURCE) ; $(CC) $(CFLAGS) -o $(PROGRAM) $(SOURCE)
      

--- a/spectre.c
+++ b/spectre.c
@@ -201,6 +201,11 @@ int main(int argc,
 
     sscanf(argv[3], "%d", &len);
   }
+
+  /* Print git commit hash */
+  #ifdef GIT_COMMIT_HASH
+    printf("Version: commit " GIT_COMMIT_HASH "\n");
+  #endif
   
   /* Print cache hit threshold */
   printf("Using a cache hit threshold of %d.\n", cache_hit_threshold);


### PR DESCRIPTION
I thought it would be nice if the printed results contained the git commit hash the program was compiled from. This way the results would be more reproducible.