### PR TITLE
Use switch for SSE2 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,17 @@ To build the project without `clflush`, define the NOCLFLUSH cflag:
 
 `CFLAGS=-DNOCLFLUSH make`
 
+#### Multiple cflags
+
 To define multiple cflags, separate each cflag with an escaped space. For example:
 
 `CFLAGS=-DNORDTSCP\ -DNOMFENCE\ -DNOCLFLUSH make`
+
+#### SSE2 instruction set
+
+To build the project without all of the above instructions introduced with SSE2, define NOSSE2 cflag:
+
+`CFLAGS=-DNOSSE2 make`
 
 ### Building it without using the Makefile
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ To build the project without all of the above instructions introduced with SSE2,
 
 `CFLAGS=-DNOSSE2 make`
 
+#### 'Target specific option mismatch' error
+
+Some 32-bit versions of gcc (e.g. the version used in Ubuntu 14.04) may show the following error while compiling the PoC:
+
+```
+/usr/lib/gcc/i686-linux-gnu/5/include/emmintrin.h:1479:1: error:
+  inlining failed in call to always_inline
+`_mm_clflush`: target specific option mismatch
+ _mm_clflush (void const *__A)
+ ^
+```
+
+In this case architecture build flag `-march=native` is required for compilation for the current CPU:
+
+`CFLAGS=-march=native make`
+
+This flag builds the binary specifically for the current CPU and it may crash after copying to another machine.
+
 ### Building it without using the Makefile
 
 If you want to build it manually, make sure to disable all optimisations (aka, don't use -O2), as it will break the program.

--- a/spectre.c
+++ b/spectre.c
@@ -21,6 +21,12 @@
 #include <x86intrin.h> /* for rdtsc, rdtscp, clflush */
 #endif
 
+#ifdef NOSSE2
+#define NORDTSCP
+#define NOMFENCE
+#define NOCLFLUSH
+#endif
+
 /********************************************************************
 Victim code.
 ********************************************************************/


### PR DESCRIPTION
Added IFDEF for switching all instruction from the SSE2 set. The information about the switch was added to README.

Also I added workaround for an issue one may encounter while compiling PoC on 32-bit systems with older gcc versions.