### PR TITLE
Simple mitigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Building is as easy as:
 
 The output binary is `./spectre.out`.
 
+If you want to build a version with mitigation included, set your `CFLAGS`
+
+`CFLAGS=-DMITIGATION`
+
+in the `Makefile` or build like
+
+`CFLAGS=-DMITIGATION make`
+
+The output binary will still be in `./spectre.out`.
+
 ### Building for older CPUs
 
 Depending on the CPU, certain instructions will need to be disabled in order for the program to run correctly.

--- a/spectre.c
+++ b/spectre.c
@@ -53,6 +53,16 @@ uint8_t temp = 0; /* Used so compiler won’t optimize out victim_function() */
 
 void victim_function(size_t x) {
   if (x < array1_size) {
+#ifdef MITIGATE
+		/*
+		 * According to Intel et al, the best way to mitigate this is to 
+		 * add a serializing instruction after the boundary check to force
+		 * the retirement of previous instructions before proceeding to 
+		 * the read.
+		 * See https://newsroom.intel.com/wp-content/uploads/sites/11/2018/01/Intel-Analysis-of-Speculative-Execution-Side-Channels.pdf
+		 */
+		_mm_lfence();
+#endif
     temp &= array2[array1[x] * 512];
   }
 }


### PR DESCRIPTION
Use a serializing lfence after the boundary check to mitigate the vulnerability. This was specified by the Intel mitigation manual [here](https://newsroom.intel.com/wp-content/uploads/sites/11/2018/01/Intel-Analysis-of-Speculative-Execution-Side-Channels.pdf).

Compile with -DMITIGATION in CFLAGS to use. Documented in README.md.