### PR TITLE
Fix score of null bytes

### DIFF
--- a/spectre.c
+++ b/spectre.c
@@ -269,11 +269,11 @@ void readMemoryByte(int cache_hit_threshold, size_t malicious_x, uint8_t value[2
     if (results[j] >= (2 * results[k] + 5) || (results[j] == 2 && results[k] == 0))
       break; /* Clear success if best is > 2*runner-up + 5 or 2/0) */
   }
-  results[0] ^= junk; /* use junk so code above won’t get optimized out*/
   value[0] = (uint8_t) j;
   score[0] = results[j];
   value[1] = (uint8_t) k;
   score[1] = results[k];
+  results[0] ^= junk; /* use junk so code above won’t get optimized out*/
 }
 
 /*


### PR DESCRIPTION
At the end of `readMemoryByte`, the score of value 0 will be XORed with `junk`. This leads to an incorrect score if there are null bytes inside the memory (and if `junk` is not 0). For example, if `len` in the main function is changed to 41 (to load the null byte at the end of the secret string), then we can see that the score of the last byte is incorrect.

I changed the order of the last few lines to fix this issue.